### PR TITLE
feat(WEBION-105): Add Serilog logging with Google Cloud integration

### DIFF
--- a/Webion.Stargaze.Api/Config/LoggingConfig.cs
+++ b/Webion.Stargaze.Api/Config/LoggingConfig.cs
@@ -1,0 +1,40 @@
+using Serilog;
+using Serilog.Sinks.GoogleCloudLogging;
+using Webion.AspNetCore;
+
+namespace Webion.Stargaze.Api.Config;
+
+public sealed class LoggingConfig : IWebApplicationConfiguration
+{
+    public void Add(WebApplicationBuilder builder)
+    {
+        builder.Host.UseSerilog((ctx, services, logger) =>
+        {
+            logger
+                .ReadFrom.Configuration(ctx.Configuration)
+                .ReadFrom.Services(services);
+
+            if (builder.Environment.IsDevelopment())
+            {
+                logger.WriteTo.Console();
+            }
+            else
+            {
+                logger.WriteTo.GoogleCloudLogging(new GoogleCloudLoggingSinkOptions
+                {
+                    ProjectId = builder.Configuration["Logging:GoogleCloud:ProjectId"],
+                    ServiceName = builder.Configuration["Logging:ServiceName"],
+                    Labels =
+                    {
+                        ["env"] = builder.Environment.EnvironmentName,
+                    },
+                });
+            }
+        });
+
+    }
+
+    public void Use(WebApplication app)
+    {
+    }
+}

--- a/Webion.Stargaze.Api/Program.cs
+++ b/Webion.Stargaze.Api/Program.cs
@@ -9,6 +9,8 @@ using Webion.Stargaze.Auth;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Add<LoggingConfig>();
+
 builder.Add<ApiVersioningConfig>();
 builder.Add<SwaggerConfig>();
 builder.Add<OptionsConfig>();

--- a/Webion.Stargaze.Api/Webion.Stargaze.Api.csproj
+++ b/Webion.Stargaze.Api/Webion.Stargaze.Api.csproj
@@ -18,6 +18,8 @@
         <PackageReference Include="microsoft.aspnetcore.mvc.versioning.apiexplorer" Version="5.1.0" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
         <PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />
+        <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+        <PackageReference Include="Serilog.Sinks.GoogleCloudLogging" Version="5.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
         <PackageReference Include="Webion.AspNetCore" Version="1.0.1" />
         <PackageReference Include="Webion.Extensions.EntityFrameworkCore" Version="1.0.0" />


### PR DESCRIPTION
Included the Serilog and Serilog Google Cloud logging packages for improved logging capabilities in the API. New `LoggingConfig` file configures the services to use console logging in development and Google Cloud logging in other environments.
